### PR TITLE
Remove styling on song field mouse hover.

### DIFF
--- a/index.css
+++ b/index.css
@@ -150,6 +150,7 @@ input {
 	border-radius: 5px 5px 5px 5px;
 	-moz-border-radius: 5px 5px 5px 5px;
 	-webkit-border-radius: 5px 5px 5px 5px;
+	cursor: default;
 }
 
 #audioControlContainer {


### PR DESCRIPTION
The mouse styling should not change when the user hovers over the current song name—because this field cannot be clicked. It just displays the song name.